### PR TITLE
Use QR version 40 to increase amount of data per page

### DIFF
--- a/qr-backup
+++ b/qr-backup
@@ -404,7 +404,7 @@ def v_merge(images):
 
 def main_backup(args):
     # default settings
-    qr_version = 10
+    qr_version = 40
     error_correction = M # default, 25%
     scale = 8
     dpi = 300


### PR DESCRIPTION
The default QR code version used (version 10) results in the creation of many QR codes. This requires many more scans (and thus, much more effort) than the the highest-density QR code version 40. Furthermore, version 40 codes have higher information density over a given area that version 10, meaning their usage will save both time and paper.

Therefore, this simple pull request is to change the default QR code version from 10 to 40.