### PR TITLE
make multi-line notes look nicer

### DIFF
--- a/qr-backup
+++ b/qr-backup
@@ -1021,7 +1021,7 @@ def main_backup(args):
             note, args = args[0], args[1:]
             notes.append("Additional notes:")
             for note_line in note.split("\n"):
-                for line in textwrap.wrap(note_line, width=60, replace_whitespace=False):
+                for line in textwrap.wrap(note_line, width=80, replace_whitespace=False):
                     notes.append(line)
         elif arg == "--num-copies":
             if len(args) < 1:

--- a/qr-backup
+++ b/qr-backup
@@ -1019,6 +1019,7 @@ def main_backup(args):
             if len(args) < 1:
                 show_help("--note requires one argument")
             note, args = args[0], args[1:]
+            notes.append("Additional notes:")
             for note_line in note.split("\n"):
                 for line in textwrap.wrap(note_line, width=60, replace_whitespace=False):
                     notes.append(line)
@@ -1237,7 +1238,7 @@ def main_backup(args):
     nice_doc = f'\nThis backup was generated on {backup_date} with: {nice_cmd}'
     HOWTO += '\n'.join(textwrap.wrap(nice_doc, subsequent_indent='    ', width=150, replace_whitespace=False))
     if len(notes) > 0:
-        HOWTO += "\n" + "\n".join(["Additional note: " + note for note in notes])
+        HOWTO += "\n" + "\n".join(notes)
 
     # Print encyrption passphrase
     if encryption_passphrase is None:


### PR DESCRIPTION
This allows users to include arbitrary (longer) content without it
being broken up in multiple lines and prefixed repeatedly with
`Additional note:`, which quickly becomes redundant.

Fixes: #48
