### PR TITLE
reduce severity of verification warning and clarify warning

### DIFF
--- a/qr-backup
+++ b/qr-backup
@@ -1068,7 +1068,7 @@ def main_backup(args):
     if verbose:
         logging.basicConfig(format=LOGGING_FORMAT, level=logging.INFO)
     else:
-        logging.basicConfig(format=LOGGING_FORMAT, level=logging.FATAL)
+        logging.basicConfig(format=LOGGING_FORMAT, level=logging.WARNING)
     # Figure out input paths, output paths, and restore filename
 
     # Input: stdin, tarfile, or single file?
@@ -1433,14 +1433,14 @@ def self_test_restore(restore_cmd, input_path, output_path, output_buffer, origi
         test_restore_cmd = restore_cmd
 
     if not program_present("zbarimg"):
-        logging.fatal("Skipping digital restore verification, because zbarimg is not available.")
+        logging.warning("Skipping digital restore verification, because zbarimg is not available.")
         #sys.exit(6)
     elif not program_present("convert"):
         # convert is needed to work around a bug in zbarimg
-        logging.fatal("Skipping digital restore verification, because 'convert' is not available.")
+        logging.warning("Skipping digital restore verification, because 'convert' is not available.")
         #sys.exit(5)
     elif ubuntu_policy_problem():
-        logging.fatal("Skipping digital restore verification, because 'convert' is not available. Debian/Ubuntu forbid PDF conversion using imagemagick. More information at: https://github.com/za3k/qr-backup/tree/master/docs")
+        logging.warning("Skipping digital restore verification, because 'convert' forbids PDF conversion. More information at: https://github.com/za3k/qr-backup/blob/master/docs/FAQ.md#my-self-test-is-failing-on-ubuntu")
         #sys.exit(5)
     else:
         if use_buffers:


### PR DESCRIPTION
I was surprised to see this message when I tried qr-backup. I thought the entire process failed because there was this message (and only it):

    CRITICAL: Skipping digital restore verification, because 'convert' is not available. Debian/Ubuntu forbid PDF conversion using imagemagick. More information at: https://github.com/za3k/qr-backup/tree/master/docs

Normally, critical errors are irrevocable that basically stop the entire process. And indeed, in other places where we use logging.fatal in the program, we immediately exit.

So let's turn this into a WARNING instead.

I've also considered explicitely mentioning that the file was correctly converted, but this seems to me like a message that should come before, if --verbose is enabled. Unfortunately, --verbose looks more like a --debug to me and outputs way too much information. :) So I'm not sure how to fix that particular limitation (that we don't tell the user the file was correctly generated).

We also indicate more clearly which part of the documentation we're refering to here.

Finally, also remove the explicit reference to Debian/Ubuntu, as that seriously limits the scope of the warning. In fact, any Debian derivative (not just Ubuntu!) is going to have this problem, and I believe other distributions (e.g. Fedora, Red Hat) have implemented similar workarounds.