### PR TITLE
Treat a return code 0 as success

### DIFF
--- a/qr-backup
+++ b/qr-backup
@@ -1485,7 +1485,7 @@ def self_test_restore(restore_cmd, input_path, output_path, output_buffer, origi
             if use_encryption:
                 self_test_command += ["--encrypt", encryption_passphrase]
             self_test_returncode = subprocess.call(self_test_command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            self_test_success = (self_test_returncode)
+            self_test_success = self_test_returncode == 0
             logging.info("Self-test command was: {}".format(self_test_command))
             logging.info("Self-test exit code was: {}".format(self_test_returncode))
 


### PR DESCRIPTION
I always get this error when using qr-backup even though the generated PDF is fully functional and the SHAs match:
```
ERROR: !!Automatic digital restore verification FAILED (self-test). This indicates a bug in qr-backup. Please report this to the author at https://github.com/za3k/qr-backup/issues
```

I am a bit puzzled by this, but I guess that the exit code is interpreted incorrectly here. 0 indicates success, so the boolean should be set like in this PR.