### PR TITLE
ci: add initial GitHub Actions integration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,17 @@
+name: Tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  linux:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo pip install -r requirements.txt
+      - name: Run tests
+        run: python3 tests/test.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,9 +5,14 @@ on:
   - pull_request
 
 jobs:
-  linux:
+  test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Hopefully prevent future regressions such as gh-63.

Closes: gh-62
\---
This is currently blocked by gh-63, as we need to fix the tests before we can make sure this works as intended.