### PR TITLE
Fix Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ test:
 	python3 tests/test.py
 test-fast:
 	python3 tests/test.py --fast
+docker:
+	docker build -f installers/Dockerfile -t za3k/qr-backup:${VERSION} .
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)$(BINDIR)/qr-backup
 	rm -f $(DESTDIR)$(PREFIX)$(MANDIR)/man1/qr-backup.1

--- a/installers/Dockerfile
+++ b/installers/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bookworm
+FROM python:3.12-trixie
 
 RUN apt-get update \
    && apt-get install -y \

--- a/installers/Dockerfile
+++ b/installers/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-bookworm
 
 RUN apt-get update \
    && apt-get install -y \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pillow
-qrcode
-reedsolo
+pillow == 11.3.0
+qrcode == 8.2
+reedsolo == 1.7.0
+


### PR DESCRIPTION
With the release of Debian 13 (trixie), the Docker build no longer works. By specifying the Debian version the build is fixed.

Additionally pin `requirements.txt` dependencies to ensure build is deterministic.